### PR TITLE
When there is 1 button, make it full width

### DIFF
--- a/orangebox.html
+++ b/orangebox.html
@@ -1,5 +1,5 @@
 <template name="orangebox">
-  <div class="overlay"></div>
+  <div class="orangebox-overlay"></div>
   <div class="orangeBox">
     <div class="orangeBoxFont">
       <div class="orangeBoxWindow" style="display: none;">

--- a/orangebox.js
+++ b/orangebox.js
@@ -34,6 +34,12 @@ OrangeBox = {
     if(options["keyup"]!=null){
       $(window).keyup(options["keyup"]);
     }
+    
+	var buttonCount = $('.orangeBoxButtons > li').length; //count the buttons, if there's only one button, make it full width
+	if (buttonCount == 1) {
+		$('.orangeBoxButtons > li').css('width', '100%');
+	}
+    
     this.lockBody();
     var theme = options["theme"];
     if(theme){


### PR DESCRIPTION
If the user wants one modal to have a 100% width for a single button modal, but 50% for 2 button modal, it's currently impossible/difficult to do. 

This merge will automatically make all single buttons 100% width, which can be altered by other CSS rules (such as margins). This gives the user the option for 100% width single buttons, while without this merge it is not possible to do.
